### PR TITLE
Fixed a couple redundant events and the map zoom breaking on zone change

### DIFF
--- a/Classes/Cartographer.cs
+++ b/Classes/Cartographer.cs
@@ -597,25 +597,27 @@ namespace ZlizEQMap
         {
             ZoneAnnotationManager.AddNote(new ZoneAnnotation(noteText, x, y, CurrentZoneData.ShortName, CurrentZoneData.SubMapIndex));
             RefreshCurrentZoneAnnotations();
+            RaiseRedrawMaps(null, null);
         }
 
         public void RemoveNote(ZoneAnnotation zoneAnnotation)
         {
             ZoneAnnotationManager.ZoneAnnotations.Remove(zoneAnnotation);
             RefreshCurrentZoneAnnotations();
+            RaiseRedrawMaps(null, null);
         }
 
         public void SaveNotes()
         {
             ZoneAnnotationManager.SaveNotesToFile();
             RefreshCurrentZoneAnnotations();
+            RaiseRedrawMaps(null, null);
         }
 
         public void RefreshCurrentZoneAnnotations()
         {
             CurrentZoneAnnotations.Clear();
             CurrentZoneAnnotations.AddRange(ZoneAnnotationManager.GetFilteredZoneAnnotations(CurrentZoneData.ShortName, CurrentZoneData.SubMapIndex));
-            RaiseRedrawMaps(null, null);
         }
 
         public void ToggleAutoParse(bool autoParseState)

--- a/Forms/ZlizEQMapFormExperimental.cs
+++ b/Forms/ZlizEQMapFormExperimental.cs
@@ -160,6 +160,7 @@ namespace ZlizEQMap
             PopulateConnectedZones();
             SetButtonWaypointText();
             RefreshZoneAnnotationList();
+            ResizeMap();
 
             if (popoutMap != null)
             {
@@ -177,8 +178,6 @@ namespace ZlizEQMap
                 MessageBox.Show(String.Format("Unable to find zone '{0}' in Zone Data", zoneName), "ZlizEQMap", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
-
-            ZoneChangedUpdateUI();
         }
 
         private void PopulateConnectedZones()
@@ -527,8 +526,8 @@ namespace ZlizEQMap
             picBox.Width = (int)roundedX;
             picBox.Height = (int)roundedY;
 
-            ForceSetWaypoint();
-            ForceSetPlayerLocation();
+            //ForceSetWaypoint();
+            //ForceSetPlayerLocation();
         }
 
         private void buttonAutosize_Click(object sender, EventArgs e)


### PR DESCRIPTION
Fixed two bugs in the zone change logic:

1. Map zoom would get broken when zone changed and required messing with the zoom slider to get fixed
2. Player location and waypoint would get reset on map change

Yay bugfixes